### PR TITLE
Spike: Tier 1 semantic scene gate (pHash + color palette)

### DIFF
--- a/data/urls_semantic.txt
+++ b/data/urls_semantic.txt
@@ -1,0 +1,1 @@
+https://www.youtube.com/watch?v=13nSISwxrY4

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -66,8 +66,13 @@ def diagnose_range(input_path: str, time_range: str, config: DetectionConfig):
     # Pass 2: Get diagnostics with lookahead thresholds
     diagnostics = detector.get_diagnostics()
 
-    print(f"\n{'time':>8s}  {'frame':>6s}  {'quick':>6s}  {'hist':>6s}  {'edge':>6s}  {'score':>7s}  {'nbhood':>7s}  {'thresh':>7s}  {'cut':>3s}")
-    print("-" * 80)
+    sem_header = "  {'phash':>6s}  {'palDst':>6s}" if config.use_semantic else ""
+    header = f"\n{'time':>8s}  {'frame':>6s}  {'quick':>6s}  {'hist':>6s}  {'edge':>6s}  {'score':>7s}  {'nbhood':>7s}  {'thresh':>7s}"
+    if config.use_semantic:
+        header += f"  {'phash':>6s}  {'palDst':>6s}"
+    header += f"  {'cut':>3s}"
+    print(header)
+    print("-" * (90 if config.use_semantic else 80))
 
     for row in diagnostics:
         if row['time'] < start_time:
@@ -88,7 +93,13 @@ def diagnose_range(input_path: str, time_range: str, config: DetectionConfig):
         else:
             nbhood_str = "      -"
 
-        print(f"{row['time']:8.3f}  {row['frame']:6d}  {quick:6.1f}  {hist:6.1f}  {edge:6.1f}  {row['score']:7.1f}  {nbhood_str}  {row['threshold']:7.1f}  {marker}")
+        line = f"{row['time']:8.3f}  {row['frame']:6d}  {quick:6.1f}  {hist:6.1f}  {edge:6.1f}  {row['score']:7.1f}  {nbhood_str}  {row['threshold']:7.1f}"
+        if config.use_semantic:
+            phash_d = row.get('phash_dist', 0)
+            palette_d = row.get('palette_dist', 0.0)
+            line += f"  {phash_d:6d}  {palette_d:6.3f}"
+        line += f"  {marker}"
+        print(line)
 
     print()
 
@@ -330,6 +341,8 @@ def main():
                        help="Score mode: 'weighted' (default) or 'max' (best-of signals)")
     parser.add_argument("--diagnose", type=str, default=None,
                        help="Dump per-frame scores for a time range, e.g. '16.47-21.10'")
+    parser.add_argument("--semantic", action="store_true",
+                       help="Enable semantic scene analysis (pHash + color palette) for FP reduction")
 
     args = parser.parse_args()
 
@@ -343,6 +356,7 @@ def main():
         sensitivity=args.sensitivity,
         min_cut_distance=args.min_cut_distance,
         score_mode=args.score_mode,
+        use_semantic=args.semantic if args.semantic else None,
     )
 
     if args.debug:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -55,6 +55,13 @@ class DetectionConfig:
     fade_min_frames: int = 15  # Minimum frames for a fade transition (~0.5s at 24fps)
     fade_luminance_drop: float = 30.0  # Luminance must change by at least this much
 
+    # Semantic scene analysis (Tier 1) — optional FP reduction via pHash + color palette
+    use_semantic: bool = False
+    phash_size: int = 8  # Hash grid size (8 → 64-bit hash)
+    palette_bins: int = 8  # Bins per HSV channel for palette descriptor
+    palette_change_threshold: float = 0.3  # Min palette distance to confirm a cut
+    phash_hamming_threshold: int = 12  # Min hamming distance to confirm a cut
+
     # Threshold ranges derived from sensitivity:
     #   quick_threshold = quick_base + (1 - sensitivity) * quick_range
     #   detailed_threshold = detailed_base + (1 - sensitivity) * detailed_range
@@ -110,6 +117,11 @@ class DetectionConfig:
             "fade_luminance_threshold": "fade_luminance_threshold",
             "fade_min_frames": "fade_min_frames",
             "fade_luminance_drop": "fade_luminance_drop",
+            "use_semantic": "use_semantic",
+            "phash_size": "phash_size",
+            "palette_bins": "palette_bins",
+            "palette_change_threshold": "palette_change_threshold",
+            "phash_hamming_threshold": "phash_hamming_threshold",
         }
 
         for config_key, field_name in field_map.items():

--- a/src/core/detector.py
+++ b/src/core/detector.py
@@ -46,6 +46,7 @@ class CutDetector:
         self.all_luminance = []
         self.frame_numbers = []  # external frame numbers for timestamp calculation
 
+
     def score_frame(self, frame: Union[np.ndarray, cv2.UMat],
                     frame_number: Optional[int] = None) -> Tuple[float, Dict[str, float]]:
         """Score a single frame against its predecessor.
@@ -81,10 +82,11 @@ class CutDetector:
             self.frame_numbers.append(fn)
             return 0.0, {'first_frame': True}
 
-        # Score the frame pair
+        # Score the frame pair (semantic features computed inside when gate fires)
         score, metrics = self.metrics.combined_difference(
             self.previous_frame, frame
         )
+
         self.all_scores.append(score)
         self.all_metrics.append(metrics)
         self.frame_numbers.append(fn)
@@ -158,6 +160,23 @@ class CutDetector:
             effective_threshold = self._neighborhood_threshold(i)
 
             if score > effective_threshold:
+                # Semantic gate: reject if scene context hasn't changed.
+                # Semantic features are computed per-pair inside combined_difference
+                # (piggybacking on the existing GPU→CPU transfer), so they live
+                # in all_metrics[i] rather than separate arrays.
+                m = self.all_metrics[i]
+                if (self.config.use_semantic
+                        and 'phash_1' in m and 'phash_2' in m):
+                    hash_dist = FrameMetrics.hamming_distance(
+                        m['phash_1'], m['phash_2']
+                    )
+                    palette_dist = float(np.linalg.norm(
+                        m['palette_2'] - m['palette_1']
+                    ))
+                    if (palette_dist < self.config.palette_change_threshold
+                            and hash_dist < self.config.phash_hamming_threshold):
+                        continue  # within-scene motion, not a cut
+
                 timestamp = self.frame_numbers[i] / self.fps
                 cuts.append((i, timestamp))
                 last_cut_frame = i
@@ -360,7 +379,7 @@ class CutDetector:
         for i, (score, metrics, fn) in enumerate(zip(self.all_scores, self.all_metrics, self.frame_numbers)):
             thresh = self._neighborhood_threshold(i) if score > base_threshold else base_threshold
             lum = self.all_luminance[i] if i < len(self.all_luminance) else 0.0
-            rows.append({
+            row = {
                 'frame': fn,
                 'time': fn / self.fps,
                 'score': score,
@@ -368,7 +387,15 @@ class CutDetector:
                 'threshold': thresh,
                 'luminance': lum,
                 'is_cut': i in cut_frames,
-            })
+            }
+            if self.config.use_semantic and 'phash_1' in metrics and 'phash_2' in metrics:
+                row['phash_dist'] = FrameMetrics.hamming_distance(
+                    metrics['phash_1'], metrics['phash_2']
+                )
+                row['palette_dist'] = float(np.linalg.norm(
+                    metrics['palette_2'] - metrics['palette_1']
+                ))
+            rows.append(row)
 
         return rows
 

--- a/src/core/metrics.py
+++ b/src/core/metrics.py
@@ -125,6 +125,57 @@ class FrameMetrics:
             print(f"Error in edge_difference: {e}")
             return 0.0
 
+    def color_palette(self, frame: np.ndarray) -> np.ndarray:
+        """Extract a compact color palette descriptor from HSV histogram.
+
+        Returns a normalized 1D vector (palette_bins * 2 elements) capturing
+        the hue and saturation distribution. Fast alternative to k-means
+        dominant color extraction.
+        """
+        try:
+            hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+            bins = self.config.palette_bins
+            h_hist = cv2.calcHist([hsv], [0], None, [bins], [0, 180])
+            s_hist = cv2.calcHist([hsv], [1], None, [bins], [0, 256])
+            descriptor = np.concatenate([h_hist, s_hist]).flatten()
+            cv2.normalize(descriptor, descriptor)
+            return descriptor
+        except Exception as e:
+            logger = logging.getLogger(__name__)
+            logger.debug(f"Error in color_palette: {e}")
+            return np.zeros(self.config.palette_bins * 2, dtype=np.float32)
+
+    def phash(self, frame: np.ndarray) -> int:
+        """Compute perceptual hash via DCT.
+
+        Resizes to (hash_size*4)^2, applies DCT, keeps low-frequency
+        hash_size^2 coefficients, thresholds at median → 64-bit hash.
+        Hamming distance between hashes measures perceptual similarity.
+        """
+        try:
+            hash_size = self.config.phash_size
+            gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+            resized = cv2.resize(gray, (hash_size * 4, hash_size * 4),
+                                 interpolation=cv2.INTER_AREA)
+            dct = cv2.dct(np.float32(resized))
+            dct_low = dct[:hash_size, :hash_size]
+            median = np.median(dct_low)
+            bits = (dct_low > median).flatten()
+            # Pack bits into integer (up to 64 bits for hash_size=8)
+            hash_val = 0
+            for bit in bits:
+                hash_val = (hash_val << 1) | int(bit)
+            return hash_val
+        except Exception as e:
+            logger = logging.getLogger(__name__)
+            logger.debug(f"Error in phash: {e}")
+            return 0
+
+    @staticmethod
+    def hamming_distance(h1: int, h2: int) -> int:
+        """Count differing bits between two hashes."""
+        return bin(h1 ^ h2).count('1')
+
     def combined_difference(self, frame1: Union[np.ndarray, cv2.UMat],
                            frame2: Union[np.ndarray, cv2.UMat]) -> Tuple[float, dict]:
         """Calculate combined difference score using multiple metrics.
@@ -165,6 +216,13 @@ class FrameMetrics:
                 combined_score = weighted_score
 
             metrics['weighted_score'] = weighted_score
+
+            # Piggyback semantic features on the CPU frames we already have
+            if self.config.use_semantic:
+                metrics['phash_1'] = self.phash(f1)
+                metrics['phash_2'] = self.phash(f2)
+                metrics['palette_1'] = self.color_palette(f1)
+                metrics['palette_2'] = self.color_palette(f2)
         else:
             combined_score = quick_score
 

--- a/src/io/video_reader.py
+++ b/src/io/video_reader.py
@@ -101,16 +101,9 @@ class VideoReader:
                     yield self.buffer.popleft()
                     frames_read += 1
                 
-                # Reset counters and check performance
+                # Reset batch counter
                 if frames_read >= batch_size:
-                    batch_time = time.time() - batch_start_time
-                    fps = batch_size / batch_time if batch_time > 0 else 0
-                    
-                    if fps < self._fps * 0.8:  # Performance warning
-                        logger.warning(f"Frame reading running slower than video FPS: {fps:.2f} fps")
-                    
                     frames_read = 0
-                    batch_start_time = time.time()
                 
                 # Check if we've reached the end
                 if not self.buffer and self._cap.get(cv2.CAP_PROP_POS_FRAMES) >= self._cap.get(cv2.CAP_PROP_FRAME_COUNT):

--- a/tools/annotate_cuts.py
+++ b/tools/annotate_cuts.py
@@ -13,11 +13,13 @@ class CutAnnotator:
         self.video_id = Path(video_path).stem
         self.fps = self.video.get(cv2.CAP_PROP_FPS)
         self.cuts = self.load_cuts(cuts_file)
+        self.total_frames = int(self.video.get(cv2.CAP_PROP_FRAME_COUNT))
         self.feedback = {
             'video_id': self.video_id,
             'timestamp': datetime.now().isoformat(),
             'good_cuts': [],  # Can now contain timestamps or ranges
-            'false_positives': []
+            'false_positives': [],
+            'missed_cuts': []  # Cuts found during browse that the detector missed
         }
         self.window_name = 'Cut Review'
         cv2.namedWindow(self.window_name, cv2.WINDOW_NORMAL)
@@ -177,6 +179,103 @@ class CutAnnotator:
                 
         cv2.destroyWindow('Context View (Press Q to return)')
 
+    def browse_for_missed(self):
+        """Browse the video freely to mark missed cuts.
+
+        Controls:
+            Left/Right arrow or A/D: step 1 frame
+            Shift behavior via J/L: jump 1 second
+            Comma/Period: jump 10 seconds
+            M: mark current position as a missed cut
+            Space: play/pause
+            ESC: done
+        """
+        frame_num = 0
+        playing = False
+        marked_frames = set()
+
+        while True:
+            self.video.set(cv2.CAP_PROP_POS_FRAMES, frame_num)
+            ret, frame = self.video.read()
+            if not ret:
+                frame_num = max(0, frame_num - 1)
+                continue
+
+            display = frame.copy()
+            h, w = display.shape[:2]
+            current_time = frame_num / self.fps
+
+            # Top bar with time/frame info
+            overlay = display.copy()
+            cv2.rectangle(overlay, (0, 0), (w, 50), (0, 0, 0), -1)
+            cv2.rectangle(overlay, (0, h - 70), (w, h), (0, 0, 0), -1)
+            display = cv2.addWeighted(overlay, 0.7, display, 0.3, 0)
+
+            cv2.putText(display, f"{current_time:.2f}s  frame {frame_num}",
+                        (10, 35), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (255, 255, 255), 2)
+
+            # Show marked count
+            marked_text = f"Missed cuts marked: {len(self.feedback['missed_cuts'])}"
+            cv2.putText(display, marked_text,
+                        (w - 400, 35), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 255, 255), 2)
+
+            # Highlight if this frame is marked
+            if frame_num in marked_frames:
+                cv2.putText(display, "MARKED", (w // 2 - 60, h // 2),
+                            cv2.FONT_HERSHEY_SIMPLEX, 1.2, (0, 255, 0), 3)
+
+            # Timeline bar
+            progress = frame_num / max(1, self.total_frames)
+            bar_x = int(20 + (w - 40) * progress)
+            cv2.rectangle(display, (20, h - 55), (w - 20, h - 50), (128, 128, 128), -1)
+            cv2.circle(display, (bar_x, h - 52), 6, (0, 255, 0), -1)
+
+            # Draw marks on timeline
+            for mf in marked_frames:
+                mx = int(20 + (w - 40) * (mf / max(1, self.total_frames)))
+                cv2.line(display, (mx, h - 60), (mx, h - 45), (0, 255, 255), 2)
+
+            # Instructions
+            cv2.putText(display, "A/D: frame | J/L: 1s | ,/.: 10s | M: mark cut | Space: play | ESC: done",
+                        (10, h - 15), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 255, 255), 1)
+
+            cv2.imshow(self.window_name, display)
+
+            wait_time = int(1000 / self.fps) if playing else 1
+            key = cv2.waitKey(wait_time) & 0xFF
+
+            if key == 27:  # ESC
+                break
+            elif key == ord('m'):
+                if frame_num not in marked_frames:
+                    marked_frames.add(frame_num)
+                    self.feedback['missed_cuts'].append(round(current_time, 3))
+                    self.feedback['good_cuts'].append(round(current_time, 3))
+            elif key == ord(' '):
+                playing = not playing
+            elif key in [2, ord('a')]:  # Left / A
+                playing = False
+                frame_num = max(0, frame_num - 1)
+            elif key in [3, ord('d')]:  # Right / D
+                playing = False
+                frame_num = min(self.total_frames - 1, frame_num + 1)
+            elif key == ord('j'):  # Back 1s
+                playing = False
+                frame_num = max(0, frame_num - int(self.fps))
+            elif key == ord('l'):  # Forward 1s
+                playing = False
+                frame_num = min(self.total_frames - 1, frame_num + int(self.fps))
+            elif key == ord(','):  # Back 10s
+                playing = False
+                frame_num = max(0, frame_num - int(self.fps * 10))
+            elif key == ord('.'):  # Forward 10s
+                playing = False
+                frame_num = min(self.total_frames - 1, frame_num + int(self.fps * 10))
+            elif playing:
+                frame_num = min(self.total_frames - 1, frame_num + 1)
+                if frame_num >= self.total_frames - 1:
+                    playing = False
+
     def save_feedback(self, output_file: str):
         """Save annotation feedback."""
         with open(output_file, 'w') as f:
@@ -238,15 +337,23 @@ def main():
                 
             reviewed += 1
 
+        # Browse mode for missed cuts
+        print("[cyan]Entering browse mode — scrub through the video to mark missed cuts.[/cyan]")
+        print("[cyan]Press ESC when done.[/cyan]")
+        cv2.setWindowTitle(annotator.window_name, 'Browse — mark missed cuts (M to mark, ESC to finish)')
+        annotator.browse_for_missed()
+
         # Save results
         annotator.save_feedback(output_file)
-        
+
         # Show final statistics in a window
+        missed = len(annotator.feedback['missed_cuts'])
         stats_text = [
             f"Annotation Complete",
-            f"Reviewed: {reviewed}/{total_cuts} cuts",
-            f"Correct cuts: {len(annotator.feedback['good_cuts'])}",
+            f"Reviewed: {reviewed}/{total_cuts} detected cuts",
+            f"Correct cuts: {len(annotator.feedback['good_cuts']) - missed}",
             f"Incorrect cuts: {len(annotator.feedback['false_positives'])}",
+            f"Missed cuts marked: {missed}",
             f"",
             f"Results saved to: {output_file.name}",
             f"",


### PR DESCRIPTION
## Summary

Implements Tier 1 of the semantic scene understanding spike from #2 — a per-frame pHash and HSV color-palette descriptor used as a filter on hard cut candidates. The goal was to reduce false positives where action/explosion frame changes score identically to real scene changes (the FP pattern described in #2).

**Result: implementation works, infrastructure is sound, but the FP pattern from #2 does not appear on either of our two test videos. The semantic gate filters zero cuts on both — neither helping nor hurting precision.**

This PR ships the work as a documented negative result. The feature is opt-in (`--semantic`), zero-overhead when off, and negligible-overhead when on.

## What's Implemented

- **`FrameMetrics.phash()`** — DCT-based 64-bit perceptual hash
- **`FrameMetrics.color_palette()`** — HSV histogram descriptor (8h+8s bins)
- **Semantic gate** in `CutDetector.detect_cuts()` — rejects candidates only when *both* `palette_distance < 0.3` *and* `phash_hamming < 12` (i.e. perceptually identical to predecessor)
- **Zero-overhead integration** — semantic features computed inside `combined_difference()`, piggybacking on the GPU→CPU transfer that already happens when the quick gate fires. No extra `.get()` calls.
- **`--semantic` CLI flag** + new diagnostic columns (`phash`, `palDst`)
- **Annotator browse mode** — second phase after Y/N review where the user scrubs through the video to mark missed cuts (false negatives), enabling real recall measurement
- **Removed misleading "frame reading slower than FPS" warning** — it was measuring round-trip time including processing, not actual I/O

## Methodology

1. Annotated two test videos (one B&W film, one anime trailer)
2. Ran baseline + `--semantic` on both
3. Compared detection sets — **byte-identical on both videos**
4. Inspected per-cut phash/palette distributions to verify the gate had anything to filter

## Data

### Eva trailer (`13nSISwxrY4`)

| Run | Detected | TPs | FPs | Missed | Precision | Recall |
|-----|----------|-----|-----|--------|-----------|--------|
| Baseline | 39 | 35 | 4 | 93 | 89.7% | 27.3% |
| `--semantic` | 39 | 35 | 4 | 93 | 89.7% | 27.3% |

Per-cut phash distribution at all 39 detections:
- TPs: phash median **28**, range 12–40 (out of 64 bits)
- FP (1 unambiguous, the others are duplicate-detection artifacts of the one-to-one matcher): phash 24, palDst 0.985 — **higher** palette distance than the TP median (0.743). Not a "same scene" pattern.

### B&W film (`hQtH7MS2Rec`)

| Run | Detected | TPs | FPs | Missed | Precision | Recall |
|-----|----------|-----|-----|--------|-----------|--------|
| Baseline | 35 | 27 | 8 | 39 | 77.1% | 40.9% |
| `--semantic` | 35 | 27 | 8 | 39 | 77.1% | 40.9% |

## Why Zero Impact

The gate's logic is *"reject if palette AND phash are both small"* — i.e. only when the candidate is perceptually nearly identical to its predecessor. On both test videos, every detected cut crosses the threshold *because* it produces a large visual difference, and these large pixel differences correlate with large pHash deltas (median 28 of 64 bits differ). There is no candidate that scores high on pixel-difference but low on perceptual distance, so the gate never fires.

The FP pattern from #2 — *"explosion/action frame changes score identically to real scene changes"* — would manifest as: high pixel-difference score, but low pHash distance (same composition) and low palette distance (same colors). **Neither test video produces such a candidate.** Either:

- the original anime/Psycho test clips from #2 had a content quirk we haven't reproduced, or
- the existing two-pass adaptive thresholding (#4) already eliminated those FPs upstream

## What We Found Instead

Two completely different recall problems neither described in #1 nor #2:

1. **Burst-cut ceiling** — Eva trailer has cut bursts every 1–2 frames (e.g. 14.26 → 14.31 → 14.39 → 14.43), faster than `min_cut_distance=0.15s` permits. The detector physically cannot fire densely enough.
2. **Subtle-cut floor** — Black-and-white film has hard cuts producing pixel-difference scores of 0–2 (well below `quick_gate=10`). These cuts never become candidates at all.

Both warrant their own issues; neither is addressable by a precision-side filter. Follow-ups will be filed.

## Future Use

The semantic infrastructure stays in the codebase as scaffolding. When test content matching #2's stated FP pattern becomes available, the gate can be re-validated and thresholds tuned without further plumbing work.

## Test plan

- [x] `python -m src.cli.main --input <video> --semantic` runs without error
- [x] `--diagnose <range> --semantic` shows phash/palDst columns
- [x] Annotator browse mode marks missed cuts and saves to `missed_cuts` field
- [x] `tools/evaluate.py --auto -v` reports correct precision/recall

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)